### PR TITLE
Rework class DateRange, making it more fun to work with

### DIFF
--- a/Calculate Space Emissions.ipynb
+++ b/Calculate Space Emissions.ipynb
@@ -74,7 +74,7 @@
    "outputs": [],
    "source": [
     "for index, period in enumerate(periods):\n",
-    "    print(f\"Processing period from {period.start} to {period.end} ({(period.end-period.start).days} days)\")\n",
+    "    print(f\"Processing period {period}\")\n",
     "    for method in methods:\n",
     "        if method.covers(region):\n",
     "            results.setdefault(method, {})\n",
@@ -101,7 +101,7 @@
    "source": [
     "def run_method(method, region, period, index, pollutant):\n",
     "    results[method][index][pollutant] = method().run(region, period, pollutant)\n",
-    "    print(f\"Done calculating {pollutant} emissions for given region and period {period.start} to {period.end} using method {method.__name__}\")\n",
+    "    print(f\"Done calculating {pollutant} emissions for and period {period} using method {method.__name__}\")\n",
     "\n",
     "print(f\"Calculating emissions on up to {len(periods)*len(methods)*len(pollutants)} thread(s).\")\n",
     "with concurrent.futures.ThreadPoolExecutor() as executor:\n",

--- a/eocalc/methods/base.py
+++ b/eocalc/methods/base.py
@@ -18,13 +18,29 @@ class Status(Enum):
 
 
 class DateRange:
-    """Represent a time span between two dates."""
+    """Represent a time span between two dates. Includes both start and end date."""
 
     def __init__(self, start: str, end: str):
-        self.start = date.fromisoformat(start)
-        self.end = date.fromisoformat(end) + timedelta(days=1)
+        self.start = start
+        self.end = end
 
-        assert self.end > self.start, "Invalid date range!"
+    def __str__(self) -> str:
+        return f"[{self.start} to {self.end}, {len(self)} days]"
+
+    def __eq__(self, other: object) -> bool:
+        return self.__dict__ == other.__dict__ if isinstance(other, self.__class__) else False
+
+    def __ne__(self, other: object) -> bool:
+        return not self.__eq__(other)
+
+    def __len__(self) -> int:
+        return (self.end - self.start).days + 1
+
+    def __setattr__(self, key, value):
+        super.__setattr__(self, key, date.fromisoformat(value))
+
+        if hasattr(self, "start") and hasattr(self, "end") and self.end < self.start:
+            raise ValueError(f"Invalid date range, end ({self.end}) cannot be before start ({self.start})!")
 
 
 class EOEmissionCalculator(ABC):

--- a/eocalc/methods/base.py
+++ b/eocalc/methods/base.py
@@ -36,6 +36,9 @@ class DateRange:
     def __len__(self) -> int:
         return (self.end - self.start).days + 1
 
+    def __iter__(self):
+        yield from [self.start + timedelta(days=count) for count in range(len(self))]
+
     def __setattr__(self, key, value):
         super.__setattr__(self, key, date.fromisoformat(value))
 

--- a/eocalc/tests/test_base.py
+++ b/eocalc/tests/test_base.py
@@ -27,6 +27,14 @@ class TestBaseMethods(unittest.TestCase):
         self.assertNotEqual(year2019, year2020)
         self.assertEqual(366, len(year2020))
 
+        august = DateRange("2018-08-01", "2018-08-31")
+        self.assertEqual(31, len(august))
+
+        count = 0
+        for _ in august:
+            count += 1
+        self.assertEqual(31, count)
+
         with self.assertRaises(ValueError):
             DateRange(start="2019-01-01", end="2018-12-31")
         with self.assertRaises(ValueError):

--- a/eocalc/tests/test_base.py
+++ b/eocalc/tests/test_base.py
@@ -11,12 +11,28 @@ from eocalc.methods.base import DateRange, Status, EOEmissionCalculator
 class TestBaseMethods(unittest.TestCase):
 
     def test_date_range(self):
+        with self.assertRaises(TypeError):
+            DateRange()
+        with self.assertRaises(TypeError):
+            DateRange(1, "")
+        with self.assertRaises(ValueError):
+            DateRange(end="alice", start="bob")
+
         year2019 = DateRange("2019-01-01", "2019-12-31")
+        self.assertEqual(year2019, DateRange(end="2019-12-31", start="2019-01-01"))
+        self.assertEqual(365, len(year2019))
+        self.assertEqual(year2019.__str__(), "[2019-01-01 to 2019-12-31, 365 days]")
+
         year2020 = DateRange("2020-01-01", "2020-12-31")
-        self.assertEqual(365, (year2019.end-year2019.start).days)
-        self.assertEqual(366, (year2020.end-year2020.start).days)
-        with self.assertRaises(AssertionError):
-            DateRange("2019-01-01", "2018-12-31")
+        self.assertNotEqual(year2019, year2020)
+        self.assertEqual(366, len(year2020))
+
+        with self.assertRaises(ValueError):
+            DateRange(start="2019-01-01", end="2018-12-31")
+        with self.assertRaises(ValueError):
+            DateRange(start="2019-01-01", end="2019-12-31").end = "2018-12-31"
+        with self.assertRaises(ValueError):
+            DateRange(start="2019-01-01", end="2019-12-31").start = "2020-12-31"
 
     def test_covers(self):
         calc = TestEOEmissionCalculator()


### PR DESCRIPTION
- Allow Python's `len()` to return number of days covered
- Return proper `__str__`
- Throw `ValueError` if dates given are not parseable
- Add many more tests