### PR TITLE
Add Pipfile with project requirements

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,20 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+numpy = "*"
+pandas = "*"
+shapely = "*"
+geopandas = ">=0.9"
+rtree = "*"
+pyproj = "*"
+requests = "*"
+contextily = "*"
+
+[dev-packages]
+pytest = "*"
+
+[requires]
+python_version = "3.9"


### PR DESCRIPTION
Still missing: urllib? No, this is part of the standard lib  
Also, the Pipfile.lock should be included!  

This needs some proper testing.... and it turns out to be more complicated than I would like, GDAL dependencies does not easily resolve under windows, so conda might still be the better option here?!?