### PR TITLE
Create user Environment with mambaforge

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,35 +1,13 @@
-#  Requirements and Installation
+# Requirements and Installation
 
-</br>
+In order to use the spaceborne-emission calculator efficiently on your platform we recommend the usage of the "Fast Cross-Platform Package Manager" [Mamba](https://github.com/mamba-org/mamba), which will handle all the necessary dependencies for the spaceborne-emission calculator following the setup procedure described here from scratch:
 
-In order to use the spaceborne-emission calculator efficiently also on your platform we would recommend the usage of the "Fast Cross-Platform Package Manager" [Mamba](https://github.com/mamba-org/mamba), which will handle all the necessary dependencies for the spaceborne-emmission calculator following the setup procedure described here from scratch:
-
-</br>
-
-
-
-* Get the necessary python version and a packagemanager for handling virtual python environments, if you do not already have a tool for managing these environments. This is a an important step as we strongly advise you to not alter your operating systems own python environment as there is the potential to break dependencies and render other programs non-functional when installing additional packages or changing your systems python version.</br>
-We would like to reccommend to use the binary python _3.X_ installers if you start from scratch using these [Binaries](https://github.com/conda-forge/miniforge#mambaforge), which are available for most computing platforms. 
-
-</br>
-
-
-* After the installation process of the binaries you might need to close and reopen your terminal window. Windows users: please look/search for "miniforge" in your start menu and launch it to follow the next steps.
-
-</br>
-
-
-* - Create your new python environment with: [`mamba create -n py39spaceborne python=3.9`] </br>   
-For the space-emissions tool you need to use Python>=3.9.</br>
-   - Activate your new environment: [`conda activate py39spaceborne`] </br>
-   - Install your dependencies: [`mamba install jupyterlab gdal geopandas shapely numpy rtree pyproj contextily pytest sentinelsat cdsapi requests h5py netcdf4 -c conda-forge`] 
-</br>
-
-
- * The shorthand version for the three steps outlined above would be: [`mamba create -n py39spaceborne python=3.9 jupyterlab gdal geopandas shapely numpy rtree pyproj contextily pytest sentinelsat cdsapi requests h5py netcdf4 -c conda-forge`]
-</br>
-
-</br>
-
-
+* Get the necessary python version and a package manager for handling virtual python environments, if you do not already have a tool for managing these environments. This is an important step as we strongly advise you to not alter your operating systems own python environment as there is the potential to break dependencies and render other programs non-functional when installing additional packages or changing your systems python version.  
+We recommend using the binary python _3.X_ installers if you start from scratch using these [Binaries](https://github.com/conda-forge/miniforge#mambaforge), which are available for most computing platforms.
+* After the installation process of the binaries you might need to close and reopen your terminal window. (Windows users: please look/search for "miniforge" in your start menu and launch it to follow the next steps).
+   - Create your new python environment with: [`mamba create -n py39spaceborne python=3.9`]   
+For the space-emissions tool you need to use Python>=3.9.
+   - Activate your new environment: [`conda activate py39spaceborne`]
+   - Install your dependencies: [`mamba install jupyterlab gdal geopandas shapely numpy rtree pyproj contextily pytest sentinelsat cdsapi requests h5py netcdf4 -c conda-forge`]
+   - The shorthand version for the three steps outlined above would be: [`mamba create -n py39spaceborne python=3.9 jupyterlab gdal geopandas shapely numpy rtree pyproj contextily pytest sentinelsat cdsapi requests h5py netcdf4 -c conda-forge`]
 * Now you should be able to run the Jupyter notebooks from the spaceborne-emission calculator given that you have activated your new environment with [`conda activate py39spaceborne`] and you are seeing `py39spaceborne` in your shell before your command prompt. To start up Jupyter Notebook just type and execute [`jupyter-notebook`] in your shell.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,7 +2,7 @@
 
 </br>
 
-In order to use the spaceborne-emission calculator efficiently also on your platform we would reccommend the usage of the "Fast Cross-Platform Package Manager" [Mamba](https://github.com/mamba-org/mamba), which will handle all the necessary dependencies for the spaceborne-emmission calculator following the setup procedure described here from scratch:
+In order to use the spaceborne-emission calculator efficiently also on your platform we would recommend the usage of the "Fast Cross-Platform Package Manager" [Mamba](https://github.com/mamba-org/mamba), which will handle all the necessary dependencies for the spaceborne-emmission calculator following the setup procedure described here from scratch:
 
 </br>
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -22,11 +22,11 @@ We would like to reccommend to use the binary python _3.X_ installers if you sta
 * - Create your new python environment with: [`mamba create -n py39spaceborne python=3.9`] </br>   
 For the space-emissions tool you need to use Python>=3.9.</br>
    - Activate your new environment: [`conda activate py39spaceborne`] </br>
-   - Install your dependencies: [`mamba install jupyterlab gdal geopandas shapely numpy rtree pyproj contextily pytest sentinelsat cdsapi requests -c conda-forge`] 
+   - Install your dependencies: [`mamba install jupyterlab gdal geopandas shapely numpy rtree pyproj contextily pytest sentinelsat cdsapi requests h5py netcdf4 -c conda-forge`] 
 </br>
 
 
- * The shorthand version for the three steps outlined above would be: [`mamba create -n py39spaceborne python=3.9 jupyterlab gdal geopandas shapely numpy rtree pyproj contextily pytest sentinelsat cdsapi requests -c conda-forge`]
+ * The shorthand version for the three steps outlined above would be: [`mamba create -n py39spaceborne python=3.9 jupyterlab gdal geopandas shapely numpy rtree pyproj contextily pytest sentinelsat cdsapi requests h5py netcdf4 -c conda-forge`]
 </br>
 
 </br>

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -16,4 +16,4 @@ Install your dependencies: [`mamba install jupyterlab gdal geopandas shapely num
 The shorthand version would be: [`mamba create -n py39spaceborne python=3.9 jupyterlab gdal geopandas shapely numpy rtree pyproj contextily pytest requests`]
 
 
-* Now you should be able to run the Jupyter notebooks from the spaceborne-emission calculator given that you have activated your new environment with [`conda activate py39spaceborne`] and you are seeing `py39spaceborne` in your shell before your command prompt. To start up Jupyter Notebook just type and execute [`jupyter -notebook`] in your shell.
+* Now you should be able to run the Jupyter notebooks from the spaceborne-emission calculator given that you have activated your new environment with [`conda activate py39spaceborne`] and you are seeing `py39spaceborne` in your shell before your command prompt. To start up Jupyter Notebook just type and execute [`jupyter-notebook`] in your shell.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,6 +1,6 @@
 #  Requirements and Installation
 
-In order to use the spaceborne-emission calculator efficiently also on your platform we would reccommend the usage of the "Fast Cross-Platform Package Manager" [Mamba](https://github.com/mamba-org/mamba), which will handle all the necessary dependencies for the spaceborne-emmission calculator following the setup procedure described here from the scratch:
+In order to use the spaceborne-emission calculator efficiently also on your platform we would reccommend the usage of the "Fast Cross-Platform Package Manager" [Mamba](https://github.com/mamba-org/mamba), which will handle all the necessary dependencies for the spaceborne-emmission calculator following the setup procedure described here from scratch:
 
 * Get the necessary python version and a packagemanager for handling virtual python environments, if you do not already have a tool for managing these environments. This is a an important step as we strongly advise you to not alter your operating systems own python environment as there is the potential to break dependencies and render other programs non functional when installing additional packages or changing your systems python version.</br>
 We would like to reccommend to use the binary python _3.X_ installers if you start from scratch using these [Binaries](https://github.com/conda-forge/miniforge#mambaforge), which are available for most computing platforms. 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -12,8 +12,8 @@ We would like to reccommend to use the binary python _3.X_ installers if you sta
 * Create your new python environment with: [`mamba create -n py39spaceborne python=3.9`] </br>   
 For the space-emissions tool you need to use Python>=3.9.</br>
 Activate your new environment: [`conda activate py39spaceborne`] </br>
-Install your dependencies: [`mamba install jupyterlab gdal geopandas shapely numpy rtree pyproj contextily pytest requests -c conda-forge`] </br>
-The shorthand version would be: [`mamba create -n py39spaceborne python=3.9 jupyterlab gdal geopandas shapely numpy rtree pyproj contextily pytest requests`]
+Install your dependencies: [`mamba install jupyterlab gdal geopandas shapely numpy rtree pyproj contextily pytest sentinelsat cdsapi requests -c conda-forge`] </br>
+The shorthand version would be: [`mamba create -n py39spaceborne python=3.9 jupyterlab gdal geopandas shapely numpy rtree pyproj contextily pytest sentinelsat cdsapi requests`]
 
 
 * Now you should be able to run the Jupyter notebooks from the spaceborne-emission calculator given that you have activated your new environment with [`conda activate py39spaceborne`] and you are seeing `py39spaceborne` in your shell before your command prompt. To start up Jupyter Notebook just type and execute [`jupyter-notebook`] in your shell.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,19 +1,35 @@
 #  Requirements and Installation
 
+</br>
+
 In order to use the spaceborne-emission calculator efficiently also on your platform we would reccommend the usage of the "Fast Cross-Platform Package Manager" [Mamba](https://github.com/mamba-org/mamba), which will handle all the necessary dependencies for the spaceborne-emmission calculator following the setup procedure described here from scratch:
 
-* Get the necessary python version and a packagemanager for handling virtual python environments, if you do not already have a tool for managing these environments. This is a an important step as we strongly advise you to not alter your operating systems own python environment as there is the potential to break dependencies and render other programs non functional when installing additional packages or changing your systems python version.</br>
+</br>
+
+
+
+* Get the necessary python version and a packagemanager for handling virtual python environments, if you do not already have a tool for managing these environments. This is a an important step as we strongly advise you to not alter your operating systems own python environment as there is the potential to break dependencies and render other programs non-functional when installing additional packages or changing your systems python version.</br>
 We would like to reccommend to use the binary python _3.X_ installers if you start from scratch using these [Binaries](https://github.com/conda-forge/miniforge#mambaforge), which are available for most computing platforms. 
 
+</br>
 
-* After the installation process of the binaries you might need to close and reopen your terminal window.
+
+* After the installation process of the binaries you might need to close and reopen your terminal window. Windows users: please look/search for "miniforge" in your start menu and launch it to follow the next steps.
+
+</br>
 
 
-* Create your new python environment with: [`mamba create -n py39spaceborne python=3.9`] </br>   
+* - Create your new python environment with: [`mamba create -n py39spaceborne python=3.9`] </br>   
 For the space-emissions tool you need to use Python>=3.9.</br>
-Activate your new environment: [`conda activate py39spaceborne`] </br>
-Install your dependencies: [`mamba install jupyterlab gdal geopandas shapely numpy rtree pyproj contextily pytest sentinelsat cdsapi requests -c conda-forge`] </br>
-The shorthand version would be: [`mamba create -n py39spaceborne python=3.9 jupyterlab gdal geopandas shapely numpy rtree pyproj contextily pytest sentinelsat cdsapi requests`]
+   - Activate your new environment: [`conda activate py39spaceborne`] </br>
+   - Install your dependencies: [`mamba install jupyterlab gdal geopandas shapely numpy rtree pyproj contextily pytest sentinelsat cdsapi requests -c conda-forge`] 
+</br>
+
+
+ * The shorthand version for the three steps outlined above would be: [`mamba create -n py39spaceborne python=3.9 jupyterlab gdal geopandas shapely numpy rtree pyproj contextily pytest sentinelsat cdsapi requests -c conda-forge`]
+</br>
+
+</br>
 
 
 * Now you should be able to run the Jupyter notebooks from the spaceborne-emission calculator given that you have activated your new environment with [`conda activate py39spaceborne`] and you are seeing `py39spaceborne` in your shell before your command prompt. To start up Jupyter Notebook just type and execute [`jupyter-notebook`] in your shell.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,19 @@
+#  Requirements and Installation
+
+In order to use the spaceborne-emission calculator efficiently also on your platform we would reccommend the usage of the "Fast Cross-Platform Package Manager" [Mamba](https://github.com/mamba-org/mamba), which will handle all the necessary dependencies for the spaceborne-emmission calculator following the setup procedure described here from the scratch:
+
+* Get the necessary python version and a packagemanager for handling virtual python environments, if you do not already have a tool for managing these environments. This is a an important step as we strongly advise you to not alter your operating systems own python environment as there is the potential to break dependencies and render other programs non functional when installing additional packages or changing your systems python version.</br>
+We would like to reccommend to use the binary python _3.X_ installers if you start from scratch using these [Binaries](https://github.com/conda-forge/miniforge#mambaforge), which are available for most computing platforms. 
+
+
+* After the installation process of the binaries you might need to close and reopen your terminal window.
+
+
+* Create your new python environment with: [`mamba create -n py39spaceborne python=3.9`] </br>   
+For the space-emissions tool you need to use Python>=3.9.</br>
+Activate your new environment: [`conda activate py39spaceborne`] </br>
+Install your dependencies: [`mamba install jupyterlab gdal geopandas shapely numpy rtree pyproj contextily pytest requests -c conda-forge`] </br>
+The shorthand version would be: [`mamba create -n py39spaceborne python=3.9 jupyterlab gdal geopandas shapely numpy rtree pyproj contextily pytest requests`]
+
+
+* Now you should be able to run the Jupyter notebooks from the spaceborne-emission calculator given that you have activated your new environment with [`conda activate py39spaceborne`] and you are seeing `py39spaceborne` in your shell before your command prompt. To start up Jupyter Notebook just type and execute [`jupyter -notebook`] in your shell.

--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ We aim at creating and then freely offering a software tool here. The program al
 
 # Installation
 
-Please refer to the INSTALL.md for a detailed setup guide of your Python environment.
+Please read the instructions in the INSTALL.md file for a detailed setup guide of your Python environment.

--- a/README.md
+++ b/README.md
@@ -5,3 +5,7 @@ Measuring NOx concentration from space is relatively easy. The pollutant's lifet
 # Tool
 
 We aim at creating and then freely offering a software tool here. The program allows for emissions inventory estimates to be compared with independently derived calculations based on satellite data. Please refer to the repository's [wiki](https://github.com/UBA-DE-Emissionsituation/space-emissions/wiki) for all the details.
+
+# Installation
+
+Please refer to the INSTALL.md for a detailed setup guide of your Python environment.


### PR DESCRIPTION
This docstring explains the creation of the neccessary Python 3.9 user environment for space-emissions. So there should be no pipenv file needed. I hope the instructions are clear enough that even mainly GUI users may setup their envs correctly using the console. This should resolve #28  .