### PR TITLE
Added tools for file handling.

### DIFF
--- a/eocalc/tools/data_handle.py
+++ b/eocalc/tools/data_handle.py
@@ -1,0 +1,228 @@
+import copy
+import numpy
+from osgeo import gdal
+import netCDF4 as Ncf
+import h5py
+
+#For Tropomi Module
+class tropomi_l2_reader:
+    @staticmethod
+    def open(filename):
+        hdf = FileIoHDF(filename)
+        hdf.load_key_attribs()
+        d2arrays = {}
+        d2arraysshape = {}
+        for j in enumerate(hdf.kessy):
+            try:
+                data = numpy.squeeze(hdf.hdf5[j[1]])
+                shp = data.shape
+                if len(data.shape) == 2:
+                    d2arrays.update({j[1]: data})
+                    d2arraysshape.update({j[1]: shp})
+            except(AttributeError):
+                print(numpy.shape(hdf.hdf5[j[1]]))
+        return d2arrays, d2arraysshape
+
+    @staticmethod
+    def grab_2d_data_arrays(d2arrays, d2arrayshape):
+        val = numpy.asarray(list(d2arrayshape.values()))
+        arr, counts = numpy.unique(val[:, 0], return_counts=True)
+        dim0 = arr[numpy.argmax(counts)]
+        arr, counts = numpy.unique(val[:, 1], return_counts=True)
+        dim1 = arr[numpy.argmax(counts)]
+        dimm = [dim0, dim1]
+        bandnames = []
+        dataarr = []
+        for j in enumerate(d2arrays.keys()):
+            t = d2arrays[j[1]].shape
+            if (t[0] == dimm[0]) and (t[1] == dimm[1]):
+                dataarr.append(d2arrays[j[1]])
+                bandnames.append(j[1])
+        return bandnames, dataarr
+
+    @staticmethod
+    def generic_ds(dataset):
+        arr, shpp = tropomi_l2_reader.open(dataset)
+        dname = dataset.split('/')[-1]  # TODO fix winproblem
+        dname = dname.split('.')[0]
+        outdir = dataset.split('/')[:-1]  # TODO get rid of HACK with os module
+        outdir = '/'.join(outdir)
+        bandnames, dataarr = tropomi_l2_reader.grab_2d_data_arrays(arr, shpp)
+        dataarr = numpy.asarray(dataarr)
+        print(outdir + '/' + dname + "_dstack")
+        GenOutput.write(dataarr, 'ENVI', outdir + '/' + dname + "_dstack")
+        header_manipulation.append_to_header(outdir + '/' + dname + "_dstack" + '.hdr', ["band names"], [bandnames],
+                                             [1, 2, 3, 4])
+        return
+
+#For Base Module
+class header_manipulation:
+    @staticmethod
+    def replace_char(string, keyword):
+        string = string.replace(']', '}\n')
+        string = string.replace('[', '{')
+        keyword = keyword.replace('/', '_')
+        keyword = keyword.replace('_', ' ')
+        keyword = keyword.strip()
+        string = keyword + '=' + string
+        return string
+
+    @staticmethod
+    def to_str_params(vector, keyword):
+        if type(vector) == list:
+            vector = str(vector)
+        elif type(vector) == numpy.ndarray:
+            if len(numpy.shape) > 1:
+                print("Array Dim >1 not supported!")
+                raise ValueError
+            vector = str(list(vector))
+        vecstring = header_manipulation.replace_char(vector, keyword)
+        return vecstring
+
+    @staticmethod
+    def crea_hdr_params(keys, values):
+        lll = []
+        for j in enumerate(keys):
+            keyy = j[1]
+            val = values[j[0]]
+            vecstring = header_manipulation.to_str_params(val, keyy)
+            lll.append(vecstring)
+        return lll
+
+    @staticmethod
+    def construct_crs_string(xres, yres, ellipsoid, ulx, uly, projection, ulpx=1, ulpy=1, projectionzone='33',
+                             projectionhemisph='N'):
+        if projection == "Geographic Lat/Lon":
+            return "map info={" + projection + ',' + str(ulpx) + ',' + str(ulpy) + ',' + str(ulx) + ',' + str(
+                uly) + ',' + str(xres) + ',' + str(yres) + ',' + ellipsoid + '}\n'
+        elif projection == "UTM":
+            return "map info={" + projection + ',' + str(ulpx) + ',' + str(ulpy) + ',' + str(ulx) + ',' + str(
+                uly) + ',' + str(xres) + ',' + str(yres) + ',' + str(projectionzone) + ',' + str(
+                projectionhemisph) + '}\n'
+        else:
+            print("No Standard Projection Information available.")
+            print("Try to choose either UTM or Geographic Lat/Lon.")
+            print("Or you don't have any CRS with this file, then all is well.")
+            return None
+
+    @staticmethod
+    def append_header_meta(headerfile, metadatalist):
+        if '.hdr' not in headerfile:
+            print('This is no headerfile we are unable to open it.')
+        try:
+            with open(headerfile, 'a') as file:
+                file.writelines(metadatalist)
+        except OSError:
+            print('file IO Error!')
+
+    @staticmethod  # call this function here!!!
+    def append_to_header(headerfile, keys, values, geoinfolist):
+        if len(geoinfolist) != 10:
+            print("geoinfolist smaller than 10 entries assuming no relevant coordinate info")
+            liste = header_manipulation.crea_hdr_params(keys, values)
+            header_manipulation.append_header_meta(headerfile, liste)
+        elif len(geoinfolist) == 10:
+            liste = header_manipulation.crea_hdr_params(keys, values)
+            geoinfo = header_manipulation.construct_crs_string(*geoinfolist)
+            liste.append(geoinfo)
+            header_manipulation.append_header_meta(headerfile, liste)
+        else:
+            print("something went wrong no data to append")
+
+
+# Generic Output Functions For Base Module
+class GenOutput:
+    @staticmethod
+    def write(array, drivername, out):
+        driver = gdal.GetDriverByName(drivername)
+        h = numpy.shape(array)
+        print(h)
+        if len(h) == 3:
+            dst_ds = driver.Create(out, h[2], h[1], h[0], gdal.GDT_Float32)
+            ka = 1
+            while ka <= h[0]:
+                hhh = ka - 1
+                dst_ds.GetRasterBand(ka).WriteArray(array[hhh, :, :])
+                ka += 1
+            dst_ds = None#TODO Add Geoinfo and Metadata
+        elif len(h) == 2:
+            h = numpy.shape(array)
+            dst_ds = driver.Create(out, h[1], h[0], 1, gdal.GDT_Float32)
+            dst_ds.GetRasterBand(1).WriteArray(array)
+            dst_ds = None#TODO Add Geoinfo and Metadata
+        else:
+            print('Strange Datashape')
+            print('Does your numpy 2d/3d array sit at the correct argument position?')
+            raise ValueError
+
+
+# Read HDF5 Everything (with all type of data), For Base Module
+class FileIoHDF:
+    def __init__(self, datafile):
+        self.datafile = datafile
+        self.hdf5 = None
+        self.kessy = None
+        try:
+            self.hdf5 = h5py.File(self.datafile, 'r')
+        except OSError:
+            print('Not a valid HDF datafile!')
+
+    @staticmethod
+    def feil(hdfobject):
+        dset = []
+        gp = []
+        dt = []
+        hdfobject.visit(lambda item: dset.append(item) if (type(hdfobject[item]) == h5py._hl.dataset.Dataset) else (
+            gp.append(item) if (type(hdfobject[item]) == h5py._hl.group.Group) else (
+                dt.append(item) if (type(hdfobject[item]) == h5py._hl.datatype.Datatype) else print(item))))
+        return dset, gp, dt
+
+    @staticmethod
+    def methode(a,b):
+        if isinstance(b,h5py.Dataset):
+            return a#dataset
+
+    @staticmethod
+    def extracto(h5objekt):
+        h5objekt.visititems(FileIoHDF.methode)
+
+    @staticmethod
+    def aff(name):
+        if isinstance(name, h5py.Dataset):
+            print(name)
+
+    def load_key_attribs(self):
+        self.kessy,b,c = FileIoHDF.feil(self.hdf5)
+        for i in enumerate(self.kessy):
+            try:
+                ii = copy.deepcopy(i[1])
+                ii = ii.replace('/', '_')
+                ii = ii.replace(' ', '_')
+                ii = ii.strip()
+                setattr(self, ii, self.hdf5.__getitem__(i[1]))
+            except AttributeError:
+                print('No Attribute found setting setattr to None for now')
+            except ValueError:
+                print('No Value found setting setattr to None for now')
+
+
+# Read netcdf with everything, for Base Module
+class FileIoNC4:
+    def __init__(self, datafile):
+        self.datafile = datafile
+        self.net4 = None
+        self.kessy = None
+        try:
+            self.net4 = Ncf.Dataset(self.datafile)
+            self.kessy = self.net4.variables.keys()
+        except OSError:
+            print('Not a valid NCDF datafile!')
+
+    def load_key_attribs(self):
+        for i in self.kessy:
+            try:
+                setattr(self, i.replace(' ', '_'), self.net4.variables[i])
+            except AttributeError:
+                print('No Attribute found setting setattr to None for now')# TODO still missing None
+            except ValueError:
+                print('No Value found setting setattr to None for now')# TODO still missing None

--- a/eocalc/tools/equal_earth_raster_area.py
+++ b/eocalc/tools/equal_earth_raster_area.py
@@ -1,0 +1,19 @@
+import numpy
+from pyproj import Proj
+
+# For Base Module
+class TransformEqEeasy:
+    @staticmethod
+    def easytrafo(long:numpy.ndarray,lat:numpy.ndarray) -> numpy.ndarray:
+        toproj=Proj("epsg:8857")
+        x,y=toproj(long,lat)#TODO check if lat is not UpsideDown in geographic Terms -> reason for fliped rasters in datasets
+        deltax = numpy.abs(x - numpy.roll(x, 1,axis=1))
+        deltay = numpy.abs(y - numpy.roll(y, 1,axis=0))
+        area = deltax*deltay# TODO in meters otherwise km:/1000000
+        return area
+
+    @staticmethod
+    def grid(startx:float, stopx:float, stepx:float, starty:float, stopy:float, stepy:float)->(numpy.ndarray,numpy.ndarray):
+        x=numpy.arange(startx, stopx, stepx)
+        y=numpy.flip(numpy.arange(starty, stopy, stepy))#TODO: Fix for Geographic_COORDINATES
+        return numpy.meshgrid(x,y)

--- a/eocalc/tools/shape_raster.py
+++ b/eocalc/tools/shape_raster.py
@@ -1,0 +1,102 @@
+import geopandas as gpd
+import numpy,copy
+from shapely.geometry import Polygon
+from fiona.crs import from_epsg
+from osgeo import gdalnumeric
+from methods import data_handle as dhdl
+
+class VectorTools:
+
+    @staticmethod
+    def geometries(lon,lat,xul,yul,xur,yur,xlr,ylr,xll,yll,xuu,yuu):
+        x=[numpy.ndarray.flatten(lon) + xul,numpy.ndarray.flatten(lon) + xur,numpy.ndarray.flatten(lon) + xlr,numpy.ndarray.flatten(lon) + xll,numpy.ndarray.flatten(lon) + xuu]
+        y=[numpy.ndarray.flatten(lat) + yul,numpy.ndarray.flatten(lat) + yur,numpy.ndarray.flatten(lat) + ylr,numpy.ndarray.flatten(lat) + yll,numpy.ndarray.flatten(lat) + yuu]
+        ulpts=[x[0],y[0]]
+        urpts=[x[1],y[1]]
+        lrpts = [x[2], y[2]]
+        llpts = [x[3], y[3]]
+        return x,y,ulpts,urpts,lrpts,llpts
+
+    @staticmethod
+    #make sure input grids are regular and square/rectangular shape for each pixel!
+    def generate_polygon_from_lolat(lon,lat,position="ct"):
+        dx=lon[:,0]-lon[:,1]#TODO all kinds of grids and vectors
+        dy =lat[0,:] - lat[1,:]#TODO all kinds of grids and vectors
+        a=numpy.unique(dx)
+        b=numpy.unique(dy)
+        if not numpy.allclose(numpy.abs(a),numpy.abs(b)):
+            print("non squareshape rasterpixels or swapped dimensions!")
+            print(a,"dx")
+            print(b,"dy")
+        numbers=numpy.abs([a,b])/2.0
+        print(numbers)
+        if position=="ct":
+            #lon, lat, xul, yul, xur, yur, xlr, ylr, xll, yll, xuu, yuu
+            lo,la,ulpts,urpts,lrpts,llpts=VectorTools.geometries(lon,lat,-numbers[0],numbers[1],numbers[0],numbers[1],numbers[0],-numbers[1],-numbers[0],-numbers[1],-numbers[0],numbers[1])
+        if position=="ul":
+            # lon, lat, xul, yul, xur, yur, xlr, ylr, xll, yll, xuu, yuu
+            lo, la,ulpts,urpts,lrpts,llpts= VectorTools.geometries(lon, lat, 0, 0, 2*numbers[0], 0, 2*numbers[0],
+                                            -2*numbers[1], 0, -2*numbers[1], 0, 0)
+        if position=="ll":
+            # lon, lat, xul, yul, xur, yur, xlr, ylr, xll, yll, xuu, yuu
+            lo, la,ulpts,urpts,lrpts,llpts= VectorTools.geometries(lon, lat, 0, 2*numbers[1], 2*numbers[0], 2*numbers[1], 2*numbers[0],
+                                            0, 0, 0, 0, 2*numbers[1])
+        if position=="lr":
+            # lon, lat, xul, yul, xur, yur, xlr, ylr, xll, yll, xuu, yuu
+            lo, la,ulpts,urpts,lrpts,llpts = VectorTools.geometries(lon, lat, -2*numbers[0], 2*numbers[1], 0, 2*numbers[1], 0,
+                                            0, -2*numbers[0], 0, -2*numbers[0], 2*numbers[1])
+        if position=="ur":
+            # lon, lat, xul, yul, xur, yur, xlr, ylr, xll, yll, xuu, yuu
+            lo, la, ulpts,urpts,lrpts,llpts = VectorTools.geometries(lon, lat, -2*numbers[0], 0, 0, 0, 0,
+                                            -2*numbers[1], -2*numbers[0], -2*numbers[1], -2*numbers[0], 0)
+        pts=[ulpts,urpts,lrpts,llpts,ulpts]
+        """else:
+            print("only ul,ll,ur,lr and ct allowed as position input")
+            print("please see the sketch below for a mxm Subpixel Matrix!")
+            print('')
+            print("ul---ur")
+            print("|----|")
+            print("|-ct-|")
+            print("|----|")
+            print("ll---lr")"""
+        return lo,la,pts
+    #super slow and clunky due to geopandas as array proc.
+    @staticmethod
+    def genartorlist(pts):
+        ptt=numpy.asarray(pts)
+        aps=ptt.shape
+        gh=[]
+        for j in numpy.arange(0,aps[2],1):
+            print(j)
+            a=Polygon(list(zip(ptt[:,0,j],ptt[:,1,j])))
+            gh.append(a)
+        dframe=gpd.GeoDataFrame(index=numpy.arange(0,len(gh),1),crs='epsg:4326',geometry=gh)
+        return gh,dframe
+
+    @staticmethod
+    def crea_em_inv_data_tno(datafile):
+        objj=dhdl.FileIoHDF(datafile)
+        objj.load_key_attribs()
+        lat=numpy.flip(numpy.asarray(objj.lat))
+        lon=numpy.asarray(objj.lon)
+        long,latt=numpy.meshgrid(lon,lat)
+        lo,la,pts=VectorTools.generate_polygon_from_lolat(long,latt,position="ct")
+        gh,dframe=VectorTools.genartorlist(pts)
+        return dframe,objj
+
+    @staticmethod
+    #for TNO Inventory data #3ddata
+    def turnintaroud(object):
+        return numpy.flip(numpy.rot90(object,2,[0,2]))
+
+    @staticmethod
+    #wrting one CAMS Dataset takes 15min here
+    def appenddata(data,gpdframe):
+        shp=data.shape
+        gdf=copy.deepcopy(gpdframe)
+        if shp[0]==12:
+            for j in numpy.arange(1,13,1):
+                gdf[str(j)]=data[j-1,:,:].flatten()
+        else:
+            print('Sth is wrong!')
+        return gdf

--- a/eocalc/tools/themis_timeseries.py
+++ b/eocalc/tools/themis_timeseries.py
@@ -1,0 +1,134 @@
+from methods import data_handle as dhdl
+import numpy
+import os
+import urllib.request
+import datetime
+import calendar
+from methods import equal_earth_raster_area as eera
+
+URLL = 'https://d1qb6yzwaaq4he.cloudfront.net/airpollution/no2col/GOME_SCIAMACHY_GOME2ab_TroposNO2_v2.3_041996-092017_temis.nc'
+LOCAL_DATA = 'data/testdata/themis_sat_series'
+LOCAL_FILE = LOCAL_DATA+'/GOME_SCIAMACHY_GOME2ab_TroposNO2_v2.3_041996-092017_temis.nc'
+
+#For Base Module
+class temporal:
+    @staticmethod
+    def split_isostring_temis(timeobject) -> numpy.ndarray:
+        L = []
+        for j in enumerate(timeobject):
+            datestring = str(j[1])[:4] + "-" + str(j[1])[4:6] + "-" + "15"
+            L.append(datetime.date.fromisoformat(datestring))
+        timearr=numpy.asarray(L)
+        return timearr
+
+    @staticmethod
+    def month_days(timearr)->numpy.ndarray:
+        L=[]
+        for j in enumerate(timearr):
+            L.append(calendar.monthrange(j[1].year,j[1].month))
+        daysarr=numpy.asarray(L)
+        return daysarr
+
+    @staticmethod
+    def time_delta(timearr,datetimeobj) -> int:
+        timepoint = numpy.repeat(datetimeobj, len(timearr))
+        timindex=numpy.argmin(numpy.abs(timearr-timepoint))
+        return timindex
+
+
+class TemisLongdata:
+
+    @staticmethod
+    def download_data(url: str, local_file: str):
+        lf = os.path.abspath(local_file)
+        if os.path.isfile(lf):
+            print(local_file + ' Already exists no download necessary')
+        else:
+            print(local_file + ' Downloading please be patient')
+            try:
+                urllib.request.urlretrieve(url, lf)
+            except(FileNotFoundError):
+                print('invalid filename')
+            return "file does not exist, downloading ..."
+
+    @staticmethod
+    def handle_time(startdate:str,stopdate:str,timevectemis:numpy.ndarray) -> (numpy.ndarray,numpy.ndarray,int,int):#TODO Handle THEMIS Time correctly
+        try:
+            startd=datetime.date.fromisoformat(startdate)
+            stopd=datetime.date.fromisoformat(stopdate)
+        except ValueError:
+            print('a string has to be in str format: YYY-MM-DD')
+            raise ValueError
+        if (stopd-startd).days<0:
+            start=stopd
+            stop=startd
+            print(start)
+            print(stop)
+        else:
+            start=startd
+            stop=stopd
+        timevec=temporal.split_isostring_temis(timevectemis)
+        dayvec=temporal.month_days(timevec)
+        startidx=temporal.time_delta(timevec,start)
+        stopidx=temporal.time_delta(timevec,stop)
+        return timevec[startidx:stopidx],dayvec[startidx:stopidx],startidx,stopidx
+
+    @staticmethod
+    def open_nc(filename:str):
+        try:
+            themis=dhdl.FileIoNC4(filename)
+            themis.load_key_attribs()
+            return themis
+        except(FileNotFoundError):
+            print ('file not found!')
+        except(OSError):
+            print ('something went wrong with the file!')
+
+    @staticmethod
+    # per squaremeter
+    def molecule():
+        multiplicator = 10 ** 15  # gain for data to get molecules_per cm
+        cminm = 10 ** 4
+        varno2 = ((multiplicator * cminm) / (6.02214 * 10 ** 23)) * 46.001
+        return varno2
+
+    @staticmethod
+    def grab_data(nc_file_object):
+        try:
+            data=numpy.asarray(nc_file_object.TroposNO2)
+            lat=numpy.asarray(nc_file_object.lat)
+            lon=numpy.asarray(nc_file_object.lon)
+            time=numpy.asarray(nc_file_object.time)
+        except(AttributeError):
+            raise AttributeError
+        rotated=numpy.rot90(data,k=2,axes=(1,0))#right direction
+        rotated[rotated < 0]=numpy.nan# TODO Pixel based spline interpolation of NoData Values, or median of neighboring months without nan, or simple kriging of data
+        lat=numpy.flip(lat)
+        return rotated,lon,lat,time
+
+    @classmethod
+    def _run(cls,urlin:str,pathout:str,startdate:str,stopdate:str):
+        cls._factor = TemisLongdata.molecule()
+        #sqg = (squaremeter * gramss) / 1000000  # tonnen
+        #output = data * sqg * 30
+        TemisLongdata.download_data(urlin,pathout)
+        nc_object=TemisLongdata.open_nc(pathout)
+        cls._rotated,cls._lon,cls._lat,cls._time=TemisLongdata.grab_data(nc_object)
+        cls._timevec,cls._dayvec,cls._startidx,cls._stopidx=TemisLongdata.handle_time(startdate,stopdate,cls._time)#TODO Fix the No of Days with the start and the stoptime
+        cls._lonmat,cls._latmat=numpy.meshgrid(cls._lon,cls._lat)
+        cls._area=eera.TransformEqEeasy.easytrafo(cls._lonmat,cls._latmat)#TODO in meters and, fix edges please!!!
+        print(cls._startidx,cls._stopidx)
+        print(cls._rotated.shape)
+        cls._rotated=cls._rotated[cls._startidx:cls._stopidx,:,:]
+        print(cls._rotated.shape,type(cls._rotated))
+        cls._rotated=cls._rotated*(cls._factor)*cls._dayvec[:,1][:,numpy.newaxis,numpy.newaxis]#TODO potential error for the units (m/vs km vs g/t)
+        print(os.path.basename(pathout))
+        dhdl.GenOutput.write(cls._rotated,'ENVI',os.path.dirname(pathout)+"/emissions_ds_ts")
+        output=numpy.nansum(cls._rotated,axis=0)#TODO Do clipping with Shapefile save as GIS Raster
+        dhdl.GenOutput.write(output, 'ENVI', os.path.dirname(pathout) + "/emissions_ds_flat")
+        nox_em=numpy.nansum(output)
+
+
+
+
+


### PR DESCRIPTION
Hello,
I added several convenience functions that I would like to discuss which span the following issues:  #11, #32, #17. 
I think the most important is the convenient read functions that pull in all attributes from the nc and hdf files. This is done very easy with the visit attribute of hdf data.
After spending some time with geopandas DFs and ordinary arrays I'd also like to provide two different ways of handling the data:
1. The original GPDF way, where clipping and projecting is easy, but where larger raster takes forever for file I/O.
2. The raster way of doing things (I only care about raster grid cells and not about fractions of a raster cell e.g. along borders) This requires the calculation of grid cell sizes which is done straight forward from numpy coordinate arrays with the equal_earth_raster array. This makes File I/O fast and efficient and allows fast/full GIS compatibility. 